### PR TITLE
Use CircleCI for staging deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,10 +83,3 @@ workflows:
       - deploy-staging:
           requires:
             - test
-      - approve-deploy-production:
-          type: approval
-          requires:
-            - deploy-staging
-      - deploy-production:
-          requires:
-            - approve-deploy-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  test:
     docker:
       - image: jiayuyi/circleci-go-gcloud:go1.11-gcloud231.0.0
     working_directory: /go/src/github.com/yi-jiayu/bus-eta-bot
@@ -44,3 +44,17 @@ jobs:
       - run:
           name: Upload coverage
           command: bash <(curl -s https://codecov.io/bash)
+  deploy-integration:
+    docker:
+      - image: google/cloud-sdk
+    steps:
+      - checkout
+      - run: pwd && ls -l
+workflows:
+  version: 2
+  build:
+    jobs:
+      - test
+      - deploy-integration:
+          requires:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           command: bash <(curl -s https://codecov.io/bash)
   deploy-staging:
     docker:
-      - image: google/cloud-sdk
+      - image: google/cloud-sdk:231.0.0
     steps:
       - run:
           name: Authorize the Google Cloud SDK
@@ -68,6 +68,13 @@ jobs:
 
             base64 -d <<< $STAGING_APP_YAML_BASE64 > web/staging.app.yaml
             gcloud --quiet app deploy --verbosity=info web/staging.app.yaml --version ${tag_escaped}
+  deploy-production:
+    docker:
+      - image: google/cloud-sdk:231.0.0
+    steps:
+      - run:
+          name: Mock deploy to production
+          command: echo "Pretending to deploy to production..."
 workflows:
   version: 2
   test_and_deploy:
@@ -76,3 +83,10 @@ workflows:
       - deploy-staging:
           requires:
             - test
+      - approve-deploy-production:
+          type: approval
+          requires:
+            - deploy-staging
+      - deploy-production:
+          requires:
+            - approve-deploy-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
       - run:
           name: Authorize the Google Cloud SDK
           command: |
-            echo $CIRCLECI_SERVICE_ACCOUNT_KEY | sudo gcloud auth activate-service-account --key-file=-
+            echo $CIRCLECI_SERVICE_ACCOUNT_KEY | gcloud auth activate-service-account --key-file=-
             gcloud --quiet config set project bus-eta-bot
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,17 +44,34 @@ jobs:
       - run:
           name: Upload coverage
           command: bash <(curl -s https://codecov.io/bash)
-  deploy-integration:
+  deploy-staging:
     docker:
       - image: google/cloud-sdk
     steps:
+      - run:
+          name: Authorize the Google Cloud SDK
+          command: |
+            echo $CIRCLECI_SERVICE_ACCOUNT_KEY | sudo gcloud auth activate-service-account --key-file=-
+            gcloud --quiet config set project bus-eta-bot
       - checkout
-      - run: pwd && ls -l
+      - run:
+          name: Deploy to staging
+          command: |
+            # embed current version into source
+            tag=$(git describe --tags)
+            date=$(date +%Y-%m-%d)
+            sed "s/VERSION/$tag/" < version.go > version.go~ && mv version.go~ version.go
+            sed "s/VERSION/$tag/; s/DATE/$date/" < index.html > index.html~ && mv index.html~ index.html
+
+            # version cannot contain dots
+            tag_escaped=$(sed "s/\./-/g" <<< ${tag})
+
+            gcloud --quiet app deploy --verbosity=info web/staging.app.yaml --version ${tag_escaped}
 workflows:
   version: 2
-  build:
+  test_and_deploy:
     jobs:
       - test
-      - deploy-integration:
+      - deploy-staging:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
             # version cannot contain dots
             tag_escaped=$(sed "s/\./-/g" <<< ${tag})
 
+            base64 -d <<< $STAGING_APP_YAML_BASE64 > web/staging.app.yaml
             gcloud --quiet app deploy --verbosity=info web/staging.app.yaml --version ${tag_escaped}
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,15 +2,13 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.11
+      - image: jiayuyi/circleci-go-gcloud:go1.11-gcloud231.0.0
     working_directory: /go/src/github.com/yi-jiayu/bus-eta-bot
     environment:
       ARTIFACTS: /tmp/artifacts
       TEST_RESULTS: /tmp/test-results
       GO111MODULE: "on"
-      GCLOUD_VERSION: "230.0.0"
     steps:
-      - run: GO111MODULE=off go get github.com/jstemmer/go-junit-report
       - checkout
       - run:
           name: Set up artifact and test result directories
@@ -21,26 +19,6 @@ jobs:
           name: Restore Go module cache
           keys:
             - go-mod-v1-{{ checksum "go.sum" }}
-      - restore_cache:
-          name: Restore cached gcloud installation
-          keys:
-            - google-cloud-sdk-v2-{{ .Environment.GCLOUD_VERSION }}
-      - run:
-          name: Install gcloud
-          command: |
-            if [ ! -f "/tmp/google-cloud-sdk/bin/gcloud" ]; then
-              curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz |
-              tar -z -x -C /tmp -f -
-            fi
-            echo 'source /tmp/google-cloud-sdk/path.bash.inc' >> $BASH_ENV
-      - run:
-          name: Update gcloud
-          command: |
-            gcloud --quiet components install app-engine-go
-            gcloud --quiet components install app-engine-python
-            if [ -n "$GCLOUD_VERSION" ]; then
-              gcloud --quiet components update --version $GCLOUD_VERSION
-            fi
       - run:
           name: Run unit tests
           command: |
@@ -57,15 +35,10 @@ jobs:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
-      - save_cache:
-          name: Cache gcloud installation
-          key: google-cloud-sdk-v2-{{ .Environment.GCLOUD_VERSION }}
-          paths:
-            - "/tmp/google-cloud-sdk"
-      - store_artifacts: # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+      - store_artifacts:
           path: /tmp/artifacts
           destination: artifacts
-      - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+      - store_test_results:
           path: /tmp/test-results
           destination: test-results
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,6 @@ before_deploy:
   - echo $PROD_APP_YAML_V4 | base64 -d > web/prod.app.yaml
 deploy:
   - provider: script
-    script: ./deploy.sh staging
-    skip_cleanup: true
-    on:
-      all_branches: true
-      condition: -n "$TRAVIS_CI_SERVICE_ACCOUNT" && -n "$STAGING_APP_YAML"
-  - provider: script
     script: ./deploy.sh prod
     skip_cleanup: true
     on:


### PR DESCRIPTION
For the time being, I'll leave the production deployments from Travis as-is, however I'm hoping to move towards a more rapid release schedule for production as well, making use of manual deployments on CircleCI or Semaphore CI.

This closes #18.